### PR TITLE
Fix platform check android device problem

### DIFF
--- a/examples/titanium/sculejs/Resources/com.scule.js
+++ b/examples/titanium/sculejs/Resources/com.scule.js
@@ -6248,7 +6248,7 @@ var Scule = {
     /**
      * We're running inside Titanium
      */
-    if (typeof Titanium !== 'undefined' && typeof Titanium.Platform !== 'undefined') {
+    if (typeof Titanium !== 'undefined' && typeof Titanium.API !== 'undefined') {
         Scule.md5 = {
             hash: function(s) {
                 return Ti.Utils.md5HexDigest(s);


### PR DESCRIPTION
Use typeof Titanium.API to check Titanium environment to prevent crash on some Android devices.

Tested device:
- Samsung Galaxy Note II
- Samsung Galaxy 7

Error log before fix:
[ERROR] JNIUtil: Couldn't find Java class: ti/modules/titanium/platform/PlatformModule

Signed-off-by: Justin Lee lis186@gmail.com
