### PR TITLE
Allow alphabetical sorting and generate closures resilient to special ...

### DIFF
--- a/lib/com.scule.js
+++ b/lib/com.scule.js
@@ -873,7 +873,12 @@ var Scule = {
         switch(type) {
             case -1: // descending
                 collection.sort(function(v1, v2){
-                    return v2[key] - v1[key];
+                    if (v2[key] > v1[key])
+                        return 1;
+                    else if (v2[key] < v1[key])
+                        return -1;
+                    else
+                        return 0;
                 });
                 break;
 
@@ -883,7 +888,12 @@ var Scule = {
 
             case 1: // ascending
                 collection.sort(function(v1, v2){
-                    return v1[key] - v2[key];
+                    if (v2[key] > v1[key])
+                        return -1;
+                    else if (v2[key] < v1[key])
+                        return 1;
+                    else
+                        return 0;
                 });
                 break;
 
@@ -4410,7 +4420,7 @@ var Scule = {
                     var sands = this.compileExpressions(subQuery[operator]);
                     var src = 'function(o) { return (' + sands.join(' && ') + '); }';
                     if (key.indexOf('.') < 0) {
-                        clauses.push('engine.$elemMatch(o.' + key + ', ' + src + ')'); 
+                        clauses.push('engine.$elemMatch(o["' + key + '"], ' + src + ')'); 
                     } else {
                         clauses.push('engine.$elemMatch(engine.traverse(' + JSON.stringify(key) + ', o), ' + src + ')');                
                     } 
@@ -4426,7 +4436,7 @@ var Scule = {
                         v = JSON.stringify(subQuery[operator]);
                     }
                     if (key.indexOf('.') < 0) {
-                        clauses.push('engine.' + operator + '(o.' + key + ', ' + v + ')'); 
+                        clauses.push('engine.' + operator + '(o["' + key + '"], ' + v + ')'); 
                     } else {
                         clauses.push('engine.' + operator + '(engine.traverse(' + JSON.stringify(key) + ', o), ' + v + ')');                
                     }


### PR DESCRIPTION
... chars in property names. Alphabetical sorting was provided by special sort type "2", but that's not compatible with mongoDb and less powerful as it doesn't allow sorting in both directions. Special sort type "2" could be removed now, but I left it for backward compatibility.

If you have a property name obj["prop@strange"], then sculejs will throw exception because when constructing closure it uses obj.prop@strange instead of more safe obj["prop@strange"]
