### PR TITLE
Fix race condition during open of database

### DIFF
--- a/lib/com.scule.js
+++ b/lib/com.scule.js
@@ -5484,50 +5484,62 @@ var Scule = {
         /**
          * @private
          * @type {HashTable}
-         */    
+         */
         this.documents  = Scule.getPrimaryKeyIndex();
 
         /**
          * @private
          * @type {QueryInterpreter}
-         */    
+         */
         this.interpreter = Scule.getQueryInterpreter();
 
         /**
          * @private
          * @type {Number}
-         */    
+         */
         this.version     = 3.0;
 
         /**
          * @private
          * @type {ObjectId}
-         */    
+         */
         this.lastId      = null;
 
         /**
          * @private
          * @type {String}
-         */    
+         */
         this.name        = name;
 
         /**
          * @private
          * @type {Boolean}
-         */    
+         */
         this.autoCommit  = false;
 
         /**
          * @private
          * @type {Boolean}
-         */    
+         */
         this.isOpen      = false;
+
+        /**
+         * @private
+         * @type {Boolean}
+         */
+        this.isOpening   = false;
+
+        /**
+         * @private
+         * @type {Array}
+         */
+        this.callWhenOpen = [];
 
         /**
          * @private
          * @see {StorageEngine}
          * @type {StorageEngine}
-         */    
+         */
         this.storage     = null;
 
         /**
@@ -5586,8 +5598,16 @@ var Scule = {
          */
         this.open = function(callback) {
             if (this.isOpen) {
+                if (callback)
+                    callback(this);
                 return;
             }
+            if (this.isOpening) {
+                if (callback)
+                    this.callWhenOpen.push(callback);
+                return;
+            }
+            this.isOpening = true;
             var self = this;
             this.storage.read(this.name, function(o) {
                 if (!o) {
@@ -5601,9 +5621,12 @@ var Scule = {
                     }
                 }
                 self.isOpen = true;
-                if (callback) {
-                    callback(this);
-                }
+                self.isOpening = false;
+                if (callback)
+                    callback(self);
+                var cb;
+                while (cb = self.callWhenOpen.shift())
+                    cb(self);
             });
         };
 


### PR DESCRIPTION
1 out of my 10 test runs ended with mysterious error. Changes done short after the database was open where reverted to original state. The root cause is that when instance of db is created it initiates implicit open of the db. Now if you call explicitly open after you create instance db (because you want your callback to be called when the db is truly opened), that means you have two opens running concurrently. If the explicit open completes before the implicit open and further code modifies the database, the implicit open will revert those changes as it loads objects from the database file.

The callback handling in sculejs is very fragile and requires major redesign. This is just a quick fix for this particular race condition without making incompatible changes to sculejs API.