### PR TITLE
find() with _id returns array with entry undefined if object does not exist

### DIFF
--- a/lib/com.scule.js
+++ b/lib/com.scule.js
@@ -5658,10 +5658,13 @@ var Scule = {
          * @returns {Array}
          */
         this.find = function(query, conditions, callback) {
+            var result;
+
             if (Scule.global.constants.ID_FIELD in query) {
-                return [this.findOne(query[Scule.global.constants.ID_FIELD])];
+                result = this.findOne(query[Scule.global.constants.ID_FIELD]);
+                return (result) ? [result] : [];
             }
-            var result = this.interpreter.interpret(this, query, conditions);
+            result = this.interpreter.interpret(this, query, conditions);
             if (callback) {
                 callback(result);
             }


### PR DESCRIPTION
.find({_id: 'blabla'}) returns [undefined] instead of expected []